### PR TITLE
chore: remove duplicate QWidget include in DragLabelWrapper.h

### DIFF
--- a/src/DragLabelWrapper.h
+++ b/src/DragLabelWrapper.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <QQuickItem>
 #include <QWidget>
-#include <QWidget>
 #include "DragLabel.h"
 
 class DragLabelWrapper : public QQuickItem {
@@ -17,4 +16,3 @@ public:
         container->show();
     }
 };
-


### PR DESCRIPTION
### Motivation
- Remove a redundant `#include <QWidget>` in the drag-and-drop wrapper header to keep includes minimal and avoid unnecessary duplication.

### Description
- Deleted the duplicate `#include <QWidget>` line from `src/DragLabelWrapper.h` so the header now contains a single `QWidget` include.

### Testing
- No unit tests were required for this header-only cleanup; applied patch succeeded and repository verification commands (`apply_patch`, `git status`, `git show --name-only`) completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699422cb60388330972b996555f6f7c1)